### PR TITLE
Improve handling of "media_dirs" file extension config

### DIFF
--- a/mopidy/file/__init__.py
+++ b/mopidy/file/__init__.py
@@ -19,7 +19,20 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super().get_config_schema()
-        schema["media_dirs"] = config.List(optional=True)
+        schema["media_dirs"] = config.List(
+            optional=True,
+            subtype=config.Pair(
+                optional=False,
+                optional_pair=True,
+                subtypes=(
+                    config.Path(),
+                    config.String(
+                        # TODO Mpd client should accept / in dir name
+                        transformer=lambda value: value.replace(os.sep, "+")
+                    ),
+                ),
+            ),
+        )
         schema["excluded_file_extensions"] = config.List(optional=True)
         schema["show_dotfiles"] = config.Boolean(optional=True)
         schema["follow_symlinks"] = config.Boolean(optional=True)

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from mopidy import backend, exceptions, models
 from mopidy.audio import scan, tags
@@ -109,33 +108,26 @@ class FileLibraryProvider(backend.LibraryProvider):
         return [track]
 
     def _get_media_dirs(self, config):
-        for entry in config["file"]["media_dirs"]:
-            media_dir = {}
-            media_dir_split = entry.split("|", 1)
-            local_path = path.expand_path(media_dir_split[0])
-
+        for local_path, name in config["file"]["media_dirs"]:
             if local_path is None:
                 logger.debug(
                     "Failed expanding path (%s) from file/media_dirs config "
                     "value.",
-                    media_dir_split[0],
+                    local_path.original,
                 )
                 continue
             elif not local_path.is_dir():
                 logger.warning(
                     "%s is not a directory. Please create the directory or "
                     "update the file/media_dirs config value.",
-                    local_path,
+                    local_path.original,
                 )
                 continue
 
-            media_dir["path"] = local_path
-            if len(media_dir_split) == 2:
-                media_dir["name"] = media_dir_split[1]
-            else:
-                # TODO Mpd client should accept / in dir name
-                media_dir["name"] = media_dir_split[0].replace(os.sep, "+")
-
+            media_dir = {
+                "path": local_path,
+                "name": name,
+            }
             yield media_dir
 
     def _get_media_dirs_refs(self):

--- a/tests/file/test_browse.py
+++ b/tests/file/test_browse.py
@@ -11,11 +11,12 @@ from tests import path_to_data_dir
 
 @pytest.fixture
 def config():
+    media_dir = (path_to_data_dir(""), "Test Media")
     return {
         "proxy": {},
         "file": {
             "show_dotfiles": False,
-            "media_dirs": [str(path_to_data_dir(""))],
+            "media_dirs": (media_dir,),
             "excluded_file_extensions": [],
             "follow_symlinks": False,
             "metadata_timeout": 1000,

--- a/tests/file/test_lookup.py
+++ b/tests/file/test_lookup.py
@@ -14,7 +14,7 @@ def config():
         "proxy": {},
         "file": {
             "show_dotfiles": False,
-            "media_dirs": [],
+            "media_dirs": tuple(),
             "excluded_file_extensions": [],
             "follow_symlinks": False,
             "metadata_timeout": 1000,


### PR DESCRIPTION
This moves almost all of the processing for the "media_dirs" file setting into the config system, with the aim of making it more robust while also resolving some bugs. The only thing left for the file library backend to do manually now is verify that the input directories actually exist as folders.

The main bug this solves is an issue of whitespace handling around paths, as detailed in #1965.

To make this possible, the Path config type has been altered to return pathlib objects rather than strings.